### PR TITLE
fix: should work with React@0.15.0

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,6 +1,6 @@
 /* eslint no-console:0 */
 
-import 'rc-checkbox/assets/index.css';
+import 'rc-checkbox/assets/index.less';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Checkbox from 'rc-checkbox';
@@ -26,6 +26,7 @@ const Test = React.createClass({
         <p>
           <label>
             <Checkbox
+              checked
               onChange={onChange}
               disabled={this.state.disabled}
             />
@@ -39,6 +40,7 @@ const Test = React.createClass({
         <p>
           <label>
             <input
+              checked
               type="checkbox"
               onChange={onChange}
               disabled={this.state.disabled}
@@ -54,7 +56,7 @@ const Test = React.createClass({
         <p>
           <label>
             <Checkbox
-              checked
+              defaultChecked
               onChange={onChange}
               disabled={this.state.disabled}
             />
@@ -69,7 +71,7 @@ const Test = React.createClass({
           <label>
             <input
               type="checkbox"
-              checked
+              defaultChecked
               onChange={onChange}
               disabled={this.state.disabled}
             />

--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -46,7 +46,11 @@ export default class Checkbox extends React.Component {
   }
 
   render() {
-    const props = this.props;
+    const props = {...this.props};
+    // Remove React warning.
+    // Warning: Input elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both).
+    delete props.defaultChecked;
+
     const prefixCls = props.prefixCls;
     let checked = this.state.checked;
     if (typeof checked === 'boolean') {
@@ -67,9 +71,8 @@ export default class Checkbox extends React.Component {
           <span className={`${prefixCls}-inner`} />
           <input
             {...props}
-            defaultChecked={!!props.defaultChecked}
             className={`${prefixCls}-input`}
-            checked={!!checked}
+            checked={checked}
             onChange={this.handleChange}
           />
         </span>

--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -46,9 +46,10 @@ export default class Checkbox extends React.Component {
   }
 
   render() {
-    const props = {...this.props};
+    const props = { ...this.props };
     // Remove React warning.
-    // Warning: Input elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both).
+    // Warning: Input elements must be either controlled or uncontrolled
+    // (specify either the value prop, or the defaultValue prop, but not both).
     delete props.defaultChecked;
 
     const prefixCls = props.prefixCls;


### PR DESCRIPTION
Fix.

```bash
warning.js:44Warning: Input elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). 
Decide between using a controlled or uncontrolled input element and remove one of these props. More info: https://fb.me/react-controlled-components
```