### PR TITLE
Input props remove assign

### DIFF
--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -85,7 +85,8 @@ export default class Checkbox extends React.Component {
           <span className={`${prefixCls}-inner`} />
           <input
             type={props.type}
-            stype={props.style}
+            readOnly={props.readOnly}
+            disabled={props.disabled}
             className={`${prefixCls}-input`}
             checked={!!checked}
             onFocus={this.handleFocus}

--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -84,7 +84,8 @@ export default class Checkbox extends React.Component {
       >
           <span className={`${prefixCls}-inner`} />
           <input
-            {...props}
+            type={props.type}
+            stype={props.style}
             className={`${prefixCls}-input`}
             checked={!!checked}
             onFocus={this.handleFocus}


### PR DESCRIPTION
### 问题

`{...props}` 等效于 `assign({}, props)`。

assign 方法在 node 和 浏览器上表现不一致，chrome 最新版本 assign 之后，安装 key 的字母顺序。这会导致浏览器和服务器渲染不一致：

![image](https://cloud.githubusercontent.com/assets/452899/15357978/a8185588-1d34-11e6-839d-43cb68d59f22.png)

浏览器上相当于

```
<input type="checkebox" className="foo"/>
```

服务端

```
<input className="foo" type="checkebox" />
```
