### PR TITLE
Replace react-addons-pure-render-mixin with rc-util/lib/PureRenderMixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint"
   ],
   "dependencies": {
-    "react-addons-pure-render-mixin": "15.x",
-    "classnames": "2.x"
+    "classnames": "2.x",
+    "rc-util": "^4.0.1"
   }
 }

--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import PureRenderMixin from 'rc-util/lib/PureRenderMixin';
 import classNames from 'classnames';
 
 export default class Checkbox extends React.Component {


### PR DESCRIPTION
根据 https://github.com/ant-design/ant-design/issues/3338 的讨论，去掉对 react-addons-pure-render-mixin 的依赖。