### PR TITLE
render data-*, aria-* and role props to item

### DIFF
--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -88,7 +88,16 @@ export default class Checkbox extends React.Component {
       onClick,
       onFocus,
       onBlur,
+      ...others,
     } = this.props;
+
+    const globalProps = Object.keys(others).reduce((prev, key) => {
+      if (key.substr(0, 5) === 'aria-' || key.substr(0, 5) === 'data-' || key === 'role') {
+        prev[key] = others[key];
+      }
+      return prev;
+    }, {});
+
     const { checked } = this.state;
     const classString = classNames(prefixCls, className, {
       [`${prefixCls}-checked`]: checked,
@@ -109,6 +118,7 @@ export default class Checkbox extends React.Component {
           onFocus={onFocus}
           onBlur={onBlur}
           onChange={this.handleChange}
+          {...globalProps}
         />
         <span className={`${prefixCls}-inner`} />
       </span>

--- a/tests/index.js
+++ b/tests/index.js
@@ -41,4 +41,28 @@ describe('rc-checkbox', () => {
     TestUtils.scryRenderedDOMComponentsWithTag(inst, 'input')[0].click();
     expect(!!inst.state.checked).to.be(true);
   });
+
+  it('passes data-* props to input', () => {
+    ReactDOM.render(<Checkbox data-type="my-data-type" />, container, function init() {
+      inst = this;
+    });
+    const renderedInput = TestUtils.scryRenderedDOMComponentsWithTag(inst, 'input')[0];
+    expect(renderedInput.attributes['data-type'].value).to.equal('my-data-type');
+  });
+
+  it('passes aria-* props to input', () => {
+    ReactDOM.render(<Checkbox aria-label="my-aria-label" />, container, function init() {
+      inst = this;
+    });
+    const renderedInput = TestUtils.scryRenderedDOMComponentsWithTag(inst, 'input')[0];
+    expect(renderedInput.attributes['aria-label'].value).to.equal('my-aria-label');
+  });
+
+  it('passes role prop to input', () => {
+    ReactDOM.render(<Checkbox role="my-role" />, container, function init() {
+      inst = this;
+    });
+    const renderedInput = TestUtils.scryRenderedDOMComponentsWithTag(inst, 'input')[0];
+    expect(renderedInput.attributes.role.value).to.equal('my-role');
+  });
 });


### PR DESCRIPTION
This allows for passing aria-*, data-* and role as props of Checkbox which will be included in the rendered output.

I need to be able to have aria-*, data-* and role attributes rendered into the HTML to provide accessibility and automation support.  This explicitly calls out these attributes and passes them to the rendered html elements. aria-*, data-* and role are automatically supported in react components.  https://facebook.github.io/react/docs/dom-elements.html#all-supported-html-attributes

If this PR is accepted, I will be making some more to add this support to other rc components.