### PR TITLE
Pass value prop to input, because primitive html input accepts it

### DIFF
--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -20,6 +20,7 @@ export default class Checkbox extends React.Component {
     tabIndex: PropTypes.string,
     readOnly: PropTypes.bool,
     autoFocus: PropTypes.bool,
+    value: PropTypes.string,
   };
   static defaultProps = {
     prefixCls: 'rc-checkbox',
@@ -103,6 +104,7 @@ export default class Checkbox extends React.Component {
       onFocus,
       onBlur,
       autoFocus,
+      value,
       ...others,
     } = this.props;
 
@@ -135,6 +137,7 @@ export default class Checkbox extends React.Component {
           onChange={this.handleChange}
           autoFocus={autoFocus}
           ref={this.saveInput}
+          value={value}
           {...globalProps}
         />
         <span className={`${prefixCls}-inner`} />

--- a/tests/index.spec.jsx
+++ b/tests/index.spec.jsx
@@ -41,6 +41,12 @@ describe('rc-checkbox', () => {
     expect(renderedInput.attributes.role.value).toEqual('my-role');
   });
 
+  it('passes value prop to input', () => {
+    const wrapper = mount(<Checkbox value="my-custom-value" />);
+    const renderedInput = wrapper.find('input').instance();
+    expect(renderedInput.attributes.value.value).toEqual('my-custom-value');
+  });
+
   it('focus()', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);


### PR DESCRIPTION
In the regular (primitive) `<input type="checkbox" ... />` we can pass `value` prop which, if present, will be sent during sending the form. This PR makes it also possible in this checkbox component.