### PR TITLE
Label for custom css styling of checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ ReactDOM.render(<Checkbox />, container);
           <td></td>
         </tr>
         <tr>
+          <td>label</td>
+          <td>String</td>
+          <td>''</td>
+          <td>label sibling contents to input checkbox node</td>
+        </tr>
+        <tr>
           <td>className</td>
           <td>String</td>
           <td>''</td>

--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -22,6 +22,7 @@ export default class Checkbox extends React.Component {
     readOnly: PropTypes.bool,
     autoFocus: PropTypes.bool,
     value: PropTypes.any,
+    label: PropTypes.string,
   };
   static defaultProps = {
     prefixCls: 'rc-checkbox',
@@ -108,6 +109,7 @@ export default class Checkbox extends React.Component {
       onBlur,
       autoFocus,
       value,
+      label,
       ...others,
     } = this.props;
 
@@ -144,6 +146,7 @@ export default class Checkbox extends React.Component {
           value={value}
           {...globalProps}
         />
+        <label className={`${prefixCls}-label`} htmlFor={id}>{label}</label>
         <span className={`${prefixCls}-inner`} />
       </span>
     );

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,4 @@
-global.requestAnimationFrame = global.requestAnimationFrame || function (cb) {
+global.requestAnimationFrame = global.requestAnimationFrame || function requestAnimationFrame(cb) {
   return setTimeout(cb, 0);
 };
 


### PR DESCRIPTION
Using css to override styling of a checkbox requires a `<label></label>` as a sibling (same level, next element) to the `<input type="checkbox" />` node.

Without using a label with the htmlFor attr, mouse clicks don't propagate to the checkbox input, and the handleChange() callback never fires.

I was unable to make the click events propagate using the existing `<span className={${prefixCls}-inner} />`

[Reference for styling approach](https://medium.com/claritydesignsystem/pure-css-accessible-checkboxes-and-radios-buttons-54063e759bb3)