### PR TITLE
checkbox tabIndex shows incorrect warning

### DIFF
--- a/src/Checkbox.jsx
+++ b/src/Checkbox.jsx
@@ -18,7 +18,7 @@ export default class Checkbox extends React.Component {
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
-    tabIndex: PropTypes.string,
+    tabIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     readOnly: PropTypes.bool,
     autoFocus: PropTypes.bool,
     value: PropTypes.any,


### PR DESCRIPTION
The checkbox tabIndex should be a number and I think should match the antd component shown here:

https://github.com/ant-design/ant-design/blob/3ffc7f6ac207f45f1743b1b943dd24586b91152b/components/checkbox/Checkbox.tsx#L21

But after starting the pull request I noticed this was already done and suggested it be changed this number or string. Perhaps merge one of them as currently it is wrong and shows warnings. It might save more people coming here to try fix it :)