### PR TITLE
#68 Checked values not shown when printing, changed background color …

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -72,7 +72,7 @@
 
   .@{checkboxInnerPrefixCls} {
     border-color: #3dbcf6;
-    background-color: #3dbcf6;
+    box-shadow: inset 0 0 0 16px #3dbcf6;
 
     &:after {
       transform: rotate(45deg);


### PR DESCRIPTION
…to box-shadow inset

Default print option for browsers is to not print background colors, meaning that the value of this component will not be printed, unless the user changes a print setting. Box-shadows are printed, so I switched the background-color to an inset box-shadow.

I have tested in chromium and firefox.