### PR TITLE
#68 preserve background color for print

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -90,6 +90,10 @@
       animation-duration: 0.3s;
       animation-name: amCheckboxOut;
     }
+
+    @media print {
+      box-shadow: inset 0 0 0 16px #3dbcf6;
+    }
   }
 }
 
@@ -110,6 +114,10 @@
       &:after {
         animation-name: none;
         border-color: #cccccc;
+      }
+
+      @media print {
+        box-shadow: inset 0 0 0 16px #f3f3f3;
       }
     }
   }


### PR DESCRIPTION
Added box-shadow fallback for users who have not selected print background colors option(disabled by default in most browsers)

Tested in firefox and chromium, should work until IE9, see
box-shadow support
https://caniuse.com/#feat=css-boxshadow