### PR TITLE
stopPropagation

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,6 +43,7 @@ class Checkbox extends Component {
   }
 
   handleChange = (e) => {
+    e.stopPropagation();
     const { disabled, onChange } = this.props;
     if (disabled) {
       return;


### PR DESCRIPTION
修复使用 Checkbox 自定义表单组件时获取值错误的bug

重现 demo https://codesandbox.io/s/vibrant-chatterjee-osepq

使用 Checkbox.Group 自定义表单组件时，期望是在 Checkbox.Group 的 onChange 中，使用 form.setFieldsValue 来设置表单数据

![image](https://user-images.githubusercontent.com/11746742/86996433-3be53900-c1de-11ea-9330-4a37c1c9df87.png)
