### PR TITLE
chore: make dumi types can be resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint . --ext='jsx'",
     "test": "jest",
     "coverage": "jest --coverage",
-    "prepare": "husky install"
+    "prepare": "husky install && dumi setup"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,9 @@
     "esModuleInterop": true,
     "paths": {
       "@/*": ["src/*"],
-      "@@/*": ["src/.umi/*"],
+      "@@/*": [".dumi/tmp/*"],
       "rc-checkbox": ["src/index.tsx"]
     }
-  }
+  },
+  "include": [".dumi/**/*", ".dumirc.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
修复 `.dumirc.ts` 里 `defineConfig` 类型缺失的问题