### PR TITLE
fix: onChange event target miss spread props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,6 +71,7 @@ export const Checkbox = forwardRef<CheckboxRef, CheckboxProps>((props, ref) => {
     onChange?.({
       target: {
         ...props,
+        type,
         checked: e.target.checked,
       },
       stopPropagation() {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -168,6 +168,11 @@ describe('rc-checkbox', () => {
     fireEvent.click(inputEl);
 
     expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ type: 'checkbox', checked: true }),
+      }),
+    );
     expect(inputEl.checked).toBe(true);
   });
 


### PR DESCRIPTION
`onChange` 丢失 `type` 问题，导致了 antd v3 的 `rc-form` 不会响应 `checked` 时间。