### PR TITLE
chore: migrate to @rc-component namespace and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Checkbox ui component for react.
 ## Usage
 
 ```js
-import checkbox from 'rc-checkbox';
+import checkbox from '@rc-component/checkbox';
 
 export default () => <checkbox />;
 ```

--- a/docs/demo/focus.tsx
+++ b/docs/demo/focus.tsx
@@ -1,5 +1,5 @@
-import type { CheckboxRef } from 'rc-checkbox';
-import Checkbox from 'rc-checkbox';
+import type { CheckboxRef } from '@rc-component/checkbox';
+import Checkbox from '@rc-component/checkbox';
 import { useLayoutEffect, useRef, useState } from 'react';
 import '../../assets/index.less';
 

--- a/docs/demo/simple.tsx
+++ b/docs/demo/simple.tsx
@@ -1,9 +1,9 @@
 /* eslint no-console:0, jsx-a11y/label-has-for: 0, jsx-a11y/label-has-associated-control: 0 */
+import Checkbox from '@rc-component/checkbox';
 import React from 'react';
-import Checkbox from 'rc-checkbox';
 import '../../assets/index.less';
 
-import type { CheckboxProps } from 'rc-checkbox';
+import type { CheckboxProps } from '@rc-component/checkbox';
 
 const onChange = (e: any) => {
   console.log('Checkbox checked:', e.target.checked);

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 hero:
-  title: rc-checkbox
+  title: @rc-component/checkbox
   description: checkbox ui component for react
 ---
 
@@ -8,19 +8,19 @@ hero:
 
 ```bash
 # npm install
-npm install rc-checkbox --save
+npm install @rc-component/checkbox --save
 
 # yarn install
-yarn add rc-checkbox
+yarn add @rc-component/checkbox
 
 # pnpm install
-pnpm i rc-checkbox
+pnpm i @rc-component/checkbox
 ```
 
 ## 🔨 Usage
 
 ```ts
-import Checkbox from 'rc-checkbox';
+import Checkbox from '@rc-component/checkbox';
 
 export default () => {
   return <Checkbox />;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@rc-component/father-plugin": "^2.1.3",
     "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.1.5",
-    "@testing-library/react": "^14.1.2 ",
+    "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",
     "@types/classnames": "^2.3.1",
     "@types/jest": "^29.2.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "dumi build",
     "compile": "father build && lessc assets/index.less assets/index.css",
     "coverage": "jest --coverage",
-    "gh-pages": "npm run build && father doc deploy -d .docs",
+    "gh-pages": "npm run build && father doc deploy -d dist",
     "lint": "eslint src/ --ext .tsx,.ts",
     "prepare": "husky install && dumi setup",
     "prepublishOnly": "npm run compile && rc-np",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-checkbox",
-  "version": "3.5.0",
+  "name": "@rc-component/checkbox",
+  "version": "1.0.0",
   "description": "checkbox ui component for react",
   "keywords": [
     "react",
@@ -8,7 +8,7 @@
     "react-checkbox",
     "checkbox"
   ],
-  "homepage": "http://github.com/react-component/checkbox",
+  "homepage": "https://react-component.github.io/checkbox",
   "bugs": {
     "url": "http://github.com/react-component/checkbox/issues"
   },
@@ -32,9 +32,10 @@
     "gh-pages": "npm run build && father doc deploy -d .docs",
     "lint": "eslint src/ --ext .tsx,.ts",
     "prepare": "husky install && dumi setup",
-    "prepublishOnly": "npm run compile && np --yolo --no-publish",
+    "prepublishOnly": "npm run compile && rc-np",
     "start": "dumi dev",
-    "test": "jest"
+    "test": "jest",
+    "tsc": "bunx tsc --noEmit"
   },
   "lint-staged": {
     "*.{js,jsx,less,md,json}": [
@@ -45,14 +46,14 @@
     ]
   },
   "dependencies": {
-    "@babel/runtime": "^7.10.1",
-    "classnames": "^2.3.2",
-    "rc-util": "^5.25.2"
+    "@rc-component/util": "^1.3.0",
+    "classnames": "^2.3.2"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^1.0.1",
-    "@testing-library/react": "^14.1.2 ",
+    "@rc-component/father-plugin": "^2.1.3",
+    "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.1.2 ",
     "@testing-library/user-event": "^14.4.3",
     "@types/classnames": "^2.3.1",
     "@types/jest": "^29.2.4",
@@ -71,7 +72,6 @@
     "jest-environment-jsdom": "^29.3.1",
     "less": "^4.2.0",
     "lint-staged": "^15.1.0",
-    "np": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ts-node": "^10.9.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
+import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
 import classNames from 'classnames';
-import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import * as React from 'react';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 
@@ -44,9 +44,7 @@ export const Checkbox = forwardRef<CheckboxRef, CheckboxProps>((props, ref) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const holderRef = useRef<HTMLElement>(null);
 
-  const [rawValue, setRawValue] = useMergedState(defaultChecked, {
-    value: checked,
-  });
+  const [rawValue, setRawValue] = useControlledState(defaultChecked, checked);
 
   useImperativeHandle(ref, () => ({
     focus: (options) => {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,5 +1,5 @@
+import KeyCode from '@rc-component/util/lib/KeyCode';
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
 import Checkbox from '../src';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "paths": {
       "@/*": ["src/*"],
       "@@/*": [".dumi/tmp/*"],
-      "rc-checkbox": ["src/index.tsx"]
+      "@rc-component/checkbox": ["src/index.tsx"]
     }
   },
   "include": [".dumirc.ts", "**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
- 1. 迁移至 @rc-component 空间


- 2. 关联issue：https://github.com/ant-design/ant-design/issues/54854

依赖rc-util修改为 @rc-component/util
替换 useMergedState 为 useControlledState

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 无

- 文档
  - 更新示例与站点安装与导入路径为“@rc-component/checkbox”，示例代码与说明同步调整。

- 重构
  - 内部状态管理改为 useControlledState，组件对外行为与公共 API 保持不变。

- 测试
  - 调整测试中 KeyCode 的依赖来源，测试行为保持一致。

- 事务
  - 包名改为“@rc-component/checkbox”，版本重置为 1.0.0；更新构建/发布脚本、依赖为 @rc-component/util；TypeScript 路径别名同步更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->