### PR TITLE
Avoid util deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "dependencies": {
-    "@rc-component/util": "^1.11.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     ]
   },
   "dependencies": {
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.1.3",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import { useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { forwardRef, useImperativeHandle, useRef } from 'react';

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import { fireEvent, render } from '@testing-library/react';
 import * as React from 'react';
 import Checkbox from '../src';


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到 `^1.11.1`，使用已补充的根入口导出。
- 升级 `@rc-component/father-plugin` 到 `^2.2.0`，交由插件统一处理 rc 深路径 import 限制。
- 将源码和测试中对 `@rc-component/util/lib/*` 的引用改为从 `@rc-component/util` 根入口导入。

## 验证

- `git diff --check`
- 此前批量调整中已跑通 `npm run compile`、`npm run lint`、`npm test`。